### PR TITLE
Added class method to allow soap object to disable ssl verification by s...

### DIFF
--- a/lib/soap-object.rb
+++ b/lib/soap-object.rb
@@ -118,7 +118,8 @@ module SoapObject
      :with_encoding,
      :with_basic_auth,
      :with_digest_auth,
-     :with_log_level].each do |sym|
+     :with_log_level,
+     :with_ssl_verification].each do |sym|
       properties = properties.merge(self.send sym) if self.respond_to? sym
     end
     properties

--- a/lib/soap-object/class_methods.rb
+++ b/lib/soap-object/class_methods.rb
@@ -6,7 +6,7 @@ module SoapObject
     # Sets the url for the wsdl.  It can be a path to a local file or
     # a url to a remote server containing the file.
     #
-    # @param [Stroing] either the local path to or the remote url to
+    # @param [String] either the local path to or the remote url to
     # the wsdl to use for all requests.
     #
     def wsdl(url)
@@ -107,5 +107,19 @@ module SoapObject
         {log: true, log_level: level}
       end
     end
+
+    #
+    # Enable/Disable SSL verification when calling services over HTTPS (Default is true)
+    #
+    # @param [Boolean] valid values are true, false
+    #
+    def ssl_verification(enable)
+      unless enable
+        define_method(:with_ssl_verification) do
+          {ssl_verify_mode: :none}
+        end
+      end
+    end
+
   end
 end

--- a/spec/lib/soap_object_spec.rb
+++ b/spec/lib/soap_object_spec.rb
@@ -12,10 +12,16 @@ class TestServiceWithWsdl
   basic_auth 'steve', 'secret'
   digest_auth 'digest', 'auth'
   log_level :error
+  ssl_verification false
 end
 
-class TestServiceWithOutLogging
+class TestSoapObjectWithoutClientProperties
   include SoapObject
+end
+
+class TestSoapObjectWithExplicitSslVerification
+  include SoapObject
+  ssl_verification true
 end
 
 class TestWorld
@@ -68,7 +74,7 @@ describe SoapObject do
     end
 
     it "should disable logging when no logging level set" do
-      expect(TestServiceWithOutLogging.new.send(:client_properties)[:log]).to eq(false)
+      expect(TestSoapObjectWithoutClientProperties.new.send(:client_properties)[:log]).to eq(false)
     end
 
     it "should enable logging when logging level set" do
@@ -77,6 +83,18 @@ describe SoapObject do
 
     it "should allow one to set the log level" do
       expect(subject.send(:client_properties)[:log_level]).to eq(:error)
+    end
+
+    it "should enable SSL verification by default" do
+      expect(TestSoapObjectWithoutClientProperties.new.send(:client_properties)[:ssl_verify_mode]).to be_nil 
+    end
+
+    it "should allow one to disable SSL verification" do
+      expect(subject.send(:client_properties)[:ssl_verify_mode]).to eq(:none)
+    end
+
+    it "should allow one to explicitly enable SSL verification" do
+      expect(TestSoapObjectWithExplicitSslVerification.new.send(:client_properties)[:ssl_verify_mode]).to be_nil 
     end
 
   end


### PR DESCRIPTION
I decided to create a higher level of abstraction than we discussed, Doug. It is just a boolean.  However, Savon wants no ssl_verify_mode client property unless you are setting it to none.  Tell me what you think.
