### PR TITLE
Logging and SSL properties

### DIFF
--- a/lib/soap-object.rb
+++ b/lib/soap-object.rb
@@ -109,8 +109,9 @@ module SoapObject
   end
 
   def client_properties
-    properties = { log: false,
-                   ssl_verify_mode: :none }
+    properties = {log: false,
+                  ssl_verify_mode: :none,
+                  ssl_version: :SSLv3}
     [:with_wsdl,
      :with_proxy,
      :with_open_timeout,
@@ -120,7 +121,8 @@ module SoapObject
      :with_basic_auth,
      :with_digest_auth,
      :with_log_level,
-     :with_ssl_verification].each do |sym|
+     :with_ssl_verification,
+     :with_ssl_version].each do |sym|
       properties = properties.merge(self.send sym) if self.respond_to? sym
     end
     properties

--- a/lib/soap-object.rb
+++ b/lib/soap-object.rb
@@ -95,6 +95,9 @@ module SoapObject
   end
 
   private
+  DEFAULT_PROPERTIES = {log: false,
+                         ssl_verify_mode: :none,
+                         ssl_version: :SSLv3}
 
   def method_missing(*args)
     operation =args.shift
@@ -109,10 +112,8 @@ module SoapObject
   end
 
   def client_properties
-    properties = {log: false,
-                  ssl_verify_mode: :none,
-                  ssl_version: :SSLv3}
-    [:with_wsdl,
+    properties = DEFAULT_PROPERTIES
+     [:with_wsdl,
      :with_proxy,
      :with_open_timeout,
      :with_read_timeout,
@@ -123,9 +124,9 @@ module SoapObject
      :with_log_level,
      :with_ssl_verification,
      :with_ssl_version].each do |sym|
-      properties = properties.merge(self.send sym) if self.respond_to? sym
+       properties = properties.merge(self.send sym) if self.respond_to? sym
     end
-    properties
+     properties
   end
 
 end

--- a/lib/soap-object.rb
+++ b/lib/soap-object.rb
@@ -109,7 +109,8 @@ module SoapObject
   end
 
   def client_properties
-    properties = { log: false }
+    properties = { log: false,
+                   ssl_verify_mode: :none }
     [:with_wsdl,
      :with_proxy,
      :with_open_timeout,

--- a/lib/soap-object/class_methods.rb
+++ b/lib/soap-object/class_methods.rb
@@ -104,7 +104,7 @@ module SoapObject
     #
     def log_level(level)
       define_method(:with_log_level) do
-        {log: true, log_level: level}
+        {log: true, log_level: level, pretty_print_xml: true}
       end
     end
 

--- a/lib/soap-object/class_methods.rb
+++ b/lib/soap-object/class_methods.rb
@@ -121,5 +121,11 @@ module SoapObject
       end
     end
 
+    def ssl_version(version)
+      define_method(:with_ssl_version) do
+        {ssl_version: version}
+      end
+    end
+
   end
 end

--- a/lib/soap-object/class_methods.rb
+++ b/lib/soap-object/class_methods.rb
@@ -114,9 +114,9 @@ module SoapObject
     # @param [Boolean] valid values are true, false
     #
     def ssl_verification(enable)
-      unless enable
+      if enable
         define_method(:with_ssl_verification) do
-          {ssl_verify_mode: :none}
+          {ssl_verify_mode: nil}
         end
       end
     end

--- a/spec/lib/factory_spec.rb
+++ b/spec/lib/factory_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+class TestSoapObject
+  include SoapObject
+  
+  wsdl 'http://blah.com'
+end
+
+class TestWorld
+  include SoapObject::Factory
+end
+
+describe 'SoapObject factory' do
+  context "when using the factory to create to service" do
+    let(:world) { TestWorld.new }
+
+    it "should create a valid service object" do
+      service = world.using(TestSoapObject)
+      expect(service).to be_instance_of TestSoapObject
+    end
+
+    it "should create a valid service and invoke a block" do
+      world.using(TestSoapObject) do |service|
+        expect(service).to be_instance_of TestSoapObject
+      end
+    end
+
+    it "should create the service the first time we use it" do
+      obj = TestSoapObject.new
+      expect(TestSoapObject).to receive(:new).once.and_return(obj)
+      world.using(TestSoapObject)
+      world.using(TestSoapObject)
+    end
+  end
+end

--- a/spec/lib/soap_object_spec.rb
+++ b/spec/lib/soap_object_spec.rb
@@ -79,13 +79,9 @@ describe SoapObject do
       expect(subject.send(:client_properties)[:pretty_print_xml]).to eq(true)
     end
 
-    it "should enable SSL verification by default" do
-      expect(WithoutClientProperties.new.send(:client_properties)[:ssl_verify_mode]).to be_nil
+    it "should disable SSL verification by default" do
+      expect(WithoutClientProperties.new.send(:client_properties)[:ssl_verify_mode]).to eq(:none)
     end
-
-    # it "should disable SSL verification by default" do
-    #   expect(WithoutClientProperties.new.send(:client_properties)[:ssl_verify_mode]).to eq(:none)
-    # end
     #
     # it "should set SSL version to 3 by default" do
     #   expect(WithoutClientProperties.new.send(:client_properties)[:ssl_version]).to eq(:SSLv3)
@@ -103,7 +99,7 @@ describe SoapObject do
         ssl_verification false
       end
 
-      it "should allow one to explicity disable SSL verification" do
+      it "should allow one to explicitly disable SSL verification" do
         expect(WithoutSslVerification.new.send(:client_properties)[:ssl_verify_mode]).to eq(:none)
       end
 

--- a/spec/lib/soap_object_spec.rb
+++ b/spec/lib/soap_object_spec.rb
@@ -79,6 +79,10 @@ describe SoapObject do
       expect(subject.send(:client_properties)[:pretty_print_xml]).to eq(true)
     end
 
+    it "should enable SSL verification by default" do
+      expect(WithoutClientProperties.new.send(:client_properties)[:ssl_verify_mode]).to be_nil
+    end
+
     # it "should disable SSL verification by default" do
     #   expect(WithoutClientProperties.new.send(:client_properties)[:ssl_verify_mode]).to eq(:none)
     # end

--- a/spec/lib/soap_object_spec.rb
+++ b/spec/lib/soap_object_spec.rb
@@ -22,72 +22,72 @@ describe SoapObject do
   let(:client) { double('client') }
   let(:subject) { TestSoapObjectWithProperties.new }
 
-  context "when creating new instances" do
+  context 'when creating new instances' do
     before do
       allow(Savon).to receive(:client).and_return(client)
     end
 
-    it "should initialize the client using the wsdl" do
+    it 'should initialize the client using the wsdl' do
       expect(subject.send(:client_properties)[:wsdl]).to eq('http://blah.com')
     end
 
-    it "should know when it is connected to service" do
+    it 'should know when it is connected to service' do
       expect(subject).to be_connected
     end
 
-    it "should allow one to setup a proxy" do
+    it 'should allow one to setup a proxy' do
       expect(subject.send(:client_properties)[:proxy]).to eq('http://proxy.com:8080')
     end
 
-    it "should allow one to set an open timeout" do
+    it 'should allow one to set an open timeout' do
       expect(subject.send(:client_properties)[:open_timeout]).to eq(10)
     end
 
-    it "should allow one to set a read timeout" do
+    it 'should allow one to set a read timeout' do
       expect(subject.send(:client_properties)[:read_timeout]).to eq(20)
     end
 
-    it "should allow one to set a soap header" do
+    it 'should allow one to set a soap header' do
       expect(subject.send(:client_properties)[:soap_header]).to eq({'Token' => 'secret'})
     end
 
-    it "should allow one to set the encoding" do
+    it 'should allow one to set the encoding' do
       expect(subject.send(:client_properties)[:encoding]).to eq('UTF-16')
     end
 
-    it "should allow one to use basic authentication" do
+    it 'should allow one to use basic authentication' do
       expect(subject.send(:client_properties)[:basic_auth]).to eq(['steve', 'secret'])
     end
 
-    it "should allow one to use digest authentication" do
+    it 'should allow one to use digest authentication' do
       expect(subject.send(:client_properties)[:digest_auth]).to eq(['digest', 'auth'])
     end
 
-    it "should disable logging when no logging level set" do
+    it 'should disable logging when no logging level set' do
       expect(WithoutClientProperties.new.send(:client_properties)[:log]).to eq(false)
     end
 
-    it "should enable logging when logging level set" do
+    it 'should enable logging when logging level set' do
       expect(subject.send(:client_properties)[:log]).to eq(true)
     end
 
-    it "should allow one to set the log level" do
+    it 'should allow one to set the log level' do
       expect(subject.send(:client_properties)[:log_level]).to eq(:error)
     end
 
-    it "should use pretty format for xml when logging" do
+    it 'should use pretty format for xml when logging' do
       expect(subject.send(:client_properties)[:pretty_print_xml]).to eq(true)
     end
 
-    it "should disable SSL verification by default" do
+    it 'should disable SSL verification by default' do
       expect(WithoutClientProperties.new.send(:client_properties)[:ssl_verify_mode]).to eq(:none)
     end
-    #
-    # it "should set SSL version to 3 by default" do
-    #   expect(WithoutClientProperties.new.send(:client_properties)[:ssl_version]).to eq(:SSLv3)
-    # end
 
-    context "with ssl_verification" do
+    it 'should set SSL version to 3 by default' do
+      expect(WithoutClientProperties.new.send(:client_properties)[:ssl_version]).to eq(:SSLv3)
+    end
+
+    context 'with ssl_verification' do
 
       class WithSslVerification
         include SoapObject
@@ -99,19 +99,31 @@ describe SoapObject do
         ssl_verification false
       end
 
-      it "should allow one to explicitly disable SSL verification" do
+      it 'should allow one to explicitly disable SSL verification' do
         expect(WithoutSslVerification.new.send(:client_properties)[:ssl_verify_mode]).to eq(:none)
       end
 
-      it "should allow one to enable SSL verification" do
+      it 'should allow one to enable SSL verification' do
         expect(WithSslVerification.new.send(:client_properties)[:ssl_verify_mode]).to be_nil
+      end
+    end
+
+    context 'with ssl version' do
+      class WithSslVersion
+        include SoapObject
+        ssl_version :SSLv2
+
+      end
+
+      it 'should allow one to set SSL version' do
+        expect(WithSslVersion.new.send(:client_properties)[:ssl_version]).to eq(:SSLv2)
       end
     end
 
   end
 
 
-  context "when calling methods on the service" do
+  context 'when calling methods on the service' do
     let(:response) { double('response') }
 
     before do
@@ -119,13 +131,13 @@ describe SoapObject do
       expect(response).to receive(:to_xml)
     end
 
-    it "should make a valid request" do
+    it 'should make a valid request' do
       expect(client).to receive(:call).with(:fake_call, message: {data_key: 'some_value'}).and_return(response)
       subject.fake_call data_key: 'some_value'
     end
 
-    it "should make a valid request with custom xml" do
-      expected_xml = "<xml><envelope/><data></data></envelope></xml>"
+    it 'should make a valid request with custom xml' do
+      expected_xml = '<xml><envelope/><data></data></envelope></xml>'
       expect(client).to receive(:call).with(anything, xml: expected_xml).and_return(response)
       subject.fake_call expected_xml
     end


### PR DESCRIPTION
I turned on pretty_print_xml option whenever logging is enabled.
I turned off ssl verification by default which seems more appropriate for a gem used for testing.
I explicitly set SSL version to SSLv3 by default to resolve an issue with OpenSSL on Linux.
I also added a method to set the ssl_version.
I pulled out the factory specs into their own file.
